### PR TITLE
Pin python-novaclient<=6.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 xmltodict
 PrettyTable
-python-novaclient
+python-novaclient<=6.0.0
 python-keystoneclient
 python-cinderclient
 python-neutronclient


### PR DESCRIPTION
- avoid installing python-novaclient 7.0+
```
Traceback (most recent call last):
  File "./5minute.py", line 6, in <module>
    main(sys.argv[1:])
  File "/home/lpramuk/git/SatelliteQE/5minute/vminute/vminute.py", line 1435, in main
    ListInstancesClass().cmd(argv)
  File "/home/lpramuk/git/SatelliteQE/5minute/vminute/vminute.py", line 613, in cmd
    self.list_instances(filter)
  File "/home/lpramuk/git/SatelliteQE/5minute/vminute/vminute.py", line 170, in wrapper
    raise ex
keystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401) (Request-ID: req-d822744e-7cba-4e14-a80d-258d6bc9b027)
```
