### PR TITLE
Fix travis warning, pep8 was renamed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ before_install:
 install:
   - "pip install ."
   - "pip install -r requirements.txt"
-  - "pip install pep8"
+  - "pip install pycodestyle"
 script:
-  - pep8
+  - pycodestyle
 deploy:
 - provider: pypi
   skip_cleanup: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pep8]
+[pycodestyle]
 max-line-length=120


### PR DESCRIPTION
From travis log:

$ pep8
/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/pep8.py:2124: UserWarning:
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.
$ pip install pycodestyle
$ pycodestyle ...