### PR TITLE
Refactoring - configurable key name

### DIFF
--- a/vminute/vminute.py
+++ b/vminute/vminute.py
@@ -217,6 +217,7 @@ class BaseClass(object):
     __profiles = "profiles/"
     __scenarios = "scenarios/"
     __check_env_done = False
+    key_name = USER
 
     @catch_exception(
         "The configuration file ~/.5minute/config does not exist.\n"
@@ -264,7 +265,7 @@ class BaseClass(object):
     @catch_exception("Your SSL pub-key is not uploaded to the server yet. "
                      "Please use: 5minute key ~/.ssh/id_dsa.pub")
     def _check_key(self):
-        self.nova.keypairs.get(USER)
+        self.nova.keypairs.get(self.key_name)
 
     def __get_cinder(self):
         if not self.__cinder:
@@ -403,7 +404,7 @@ class KeyClass(BaseClass):
         if not os.access(key, os.R_OK):
             die("SSL key '%s' is not readable." % key)
         with open(key) as fd:
-            self.nova.keypairs.create(USER, fd.read())
+            self.nova.keypairs.create(self.key_name, fd.read())
             print(("The key %s was uploaded successfully." % key))
 
     def cmd(self, argv):
@@ -1200,7 +1201,7 @@ class BootInstanceClass(ServerClass):
         param_dict = {'name': self.variables.get('name'),
                       'image': image.id,
                       'flavor': self.variables['flavor'].id,
-                      'key_name': USER,
+                      'key_name': self.key_name,
                       'nics': [{'net-id': self.variables['private-net']}],
                       'meta': {'fqdn': self.variables["hostname"]},
                       'security_group': ['satellite5'],
@@ -1395,7 +1396,7 @@ class BootScenarioClass(ScenarioClass):
         params['name'] = "%s-%s" % (USER, params['template_name'] if 'name' not in params else params['name'])
         current_biggest_network, free_ips = self.get_network()
         stack = self.heat.stacks.create(stack_name=params['name'], template=params['template'], parameters={
-            'key_name': USER,
+            'key_name': self.key_name,
             'image': 'RHEL-6.5-Server-x86_64-released',
             'flavor': 'm1.medium',
             'public_net': current_biggest_network['id'],

--- a/vminute/vminute.py
+++ b/vminute/vminute.py
@@ -1020,6 +1020,8 @@ class BootInstanceClass(ServerClass):
                 params['noip'] = True
             elif key == '--userdata':
                 params['userdata'] = val
+            elif key == '--key-name':
+                self.key_name = val
             else:
                 die("Bad parameter '%s'. Please try 5minute boot --help." % key)
         if len(argv) != 1:
@@ -1092,8 +1094,8 @@ class BootInstanceClass(ServerClass):
                 self.__release_resources()
                 die(str(ex), exception=ex)
 
-    def help(self):
-        print("""
+    def get_help_content(self):
+        return """
          Usage: 5minute boot [PARAM]  <IMAGE-NAME|IMAGE-ID>
          Boot a new instance.
 
@@ -1104,10 +1106,15 @@ class BootInstanceClass(ServerClass):
               --novolume      no volume snapshot
               -c, --console   display the console output during booting
               --userdata      the paths or URLs to cloud-init scripts
+              --key-file      name of keypair in OpenStack cluster
 
          Examples:
              5minute boot 5minute-RHEL6
-         """)
+         """
+
+    def help(self):
+        # TODO: use inherited method from BaseClass that does the same
+        print(self.get_help_content())
 
     def __setup_networking(self):
         progress(title='Choosing a private network:')

--- a/vminute/vminute.py
+++ b/vminute/vminute.py
@@ -1552,7 +1552,7 @@ def main(argv):
         if len(argv) > 0:
             cmd = argv.pop(0)
     if cmd is None or cmd in ('help', '--help', '-h'):
-        BaseClass().cmd(argv)
+        BaseClass().help()
     elif cmd == 'key':
         KeyClass().cmd(argv)
     elif cmd == 'images':


### PR DESCRIPTION
Add ability to specify name of ssh key, if it's different from current USER environment variable.
It's implemented as generic argparser, that can be optinally used. It's prepared to extend additional `.update_arguments_parser()` per subclass to replace not-so-handy `optparse` parsing arguments.