### PR TITLE
Include additional files to be able to install the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README
+include LICENSE
+include requirements.txt
+include 5minute.spec

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     keywords='openstack testing deployment',
     install_requires=reqs,
     packages=find_packages(),
+    include_package_data=True,
     package_data={
         '': ['README.md']
     },


### PR DESCRIPTION
I found out that the 0.2.33 release could not be installed due to:
```
pip install --no-clean vminute
Collecting vminute
  Using cached https://files.pythonhosted.org/packages/f9/6d/886d8feef6963a632cd806984d137ca06d01b03433a62c56a5f561163c4b/vminute-0.2.33.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-G5juag/vminute/setup.py", line 12, in <module>
        with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
      File "/usr/lib64/python2.7/codecs.py", line 898, in open
        file = __builtin__.open(filename, mode, buffering)
    IOError: [Errno 2] No such file or directory: '/tmp/pip-install-G5juag/vminute/requirements.txt'
```

We should also include the `5minute.spec` as this file holds the info about the package version. Normally it would be setup.py who holds the version of the package. Due to RPM packaging it is the SPEC file for us.

`include_package_data`: When this is set to true, all files under version control or that are specified in the MANIFEST.in file will be included in the installation. There are more fine grained ways to specify the files you want to include

The manifest is used to specify files to include in the distribution that are not mentioned in the setup.py script